### PR TITLE
683ed1d (Brandon Philips, 27 minutes ago)    release-1.3: features-1.3: make dlorenc the minikube assignee

### DIFF
--- a/release-1.3/features-1.3.md
+++ b/release-1.3/features-1.3.md
@@ -134,12 +134,12 @@
 |  ------ | ------ |
 |  **Stage** | Alpha (Pre-release v0.3.0 - Minikube) |
 |  **Status** | In Progress |
-|  **SIG** | Node |
+|  **SIG** | Minikube |
 |  **Issue/PR links** | https://github.com/kubernetes/minikube |
-|  **Dev Lead** | https://github.com/vishh |
-|  **Assignee** | https://github.com/bgrant0607 |
-|  **Entity** | Google |
-|  **Docs** | Not Started |
+|  **Dev Lead** | https://github.com/dlorenc |
+|  **Assignee** | https://github.com/dlorenc |
+|  **Entity** | Google / CoreOS |
+|  **Docs** | https://github.com/kubernetes/minikube |
 
 |  **Item** | Stateful services (PetSet) |
 |  ------ | ------ |


### PR DESCRIPTION
dlorenc seems to be doing all of the hacking here, I don't think we should
   overload bgrant with more stuff.

7376cbd (Brandon Philips, 28 minutes ago)
   release-1.3/features-1.3: add CoreOS to minikube

   I work at CoreOS and contributed the VMware Fusion backend for minikube and
   fixed upstream libmachine bugs.