### PR TITLE
ISSUE_TEMPLATE: add a requirement for WIP docs

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -26,6 +26,8 @@ to reach Stable.
 
 
 - [ ] Before Alpha
+    - [ ] Write and maintain draft quality doc
+      - [ ] During development keep a doc up-to-date about the desired experience of the feature and how someone can try the feature in its current state. Think of it as the README of your new feature and a skeleton for the docs to be written before the Kubernetes release. Paste link to Google Doc: **DOC-LINK**
     - [ ] Design Approval
       - [ ] Design Proposal.  This goes under [docs/proposals](https://github.com/kubernetes/kubernetes/docs/proposals).  Doing a proposal as a PR allows line-by-line commenting from community, and creates the basis for later design documentation.  Paste link to merged design proposal here: **PROPOSAL-NUMBER**
       - [ ] Initial API review (if API).  Maybe same PR as design doc. **PR-NUMBER**


### PR DESCRIPTION
During the 1.3 retrospective one of the things we identified was that UX
and docs were coming long after a feature was perceived to be "done".
Further, the proposals might have changed while the feature was being
built. A few examples of this are PetSet or RBAC which landed in 1.3 but
the user experience rough sketch would have been helpful to get everyone
understanding the feature and as a starting off point for writing "real
docs".