### PR TITLE
update release blocking issue handling for 1.6

### DIFF
--- a/release-1.6/release-1.6.md
+++ b/release-1.6/release-1.6.md
@@ -59,11 +59,6 @@ link](https://docs.google.com/spreadsheets/d/1nspIeRVNjAQHRslHQD1-6gPv99OcYZLMez
   1. Any issues listed in the [v1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6)
      will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.6` milestone. Items targeting 1.7 can be moved into the `v1.7` milestone.
      milestones **or the release will not ship**
-  1. The release team *will not* use or consider the `release-blocking` or `non-release-blocking` labels although they may have meaning
-     for other members of the community
-  1. The release team *will not* user or consider `priority/*` labels of any kind. There is an ongoing migration away from `priority/p[0-9]` labels
-     in favor of `priority/[a-z]` labels and usage is inconsistent across the project.
-  1. `priority/p*` labels will continue to be used by the submit queue
 
 # Contact us
 - [via slack](https://kubernetes.slack.com/messages/k8s-release/)

--- a/release-1.6/release-1.6.md
+++ b/release-1.6/release-1.6.md
@@ -52,6 +52,18 @@ modifications:
 [Feature tracking spreadsheet
 link](https://docs.google.com/spreadsheets/d/1nspIeRVNjAQHRslHQD1-6gPv99OcYZLMezrBe3Pfhhg/edit#gid=0)
 
+## Notable operational changes
+
+1. Starting in the 1.6 release the [release team](https://github.com/kubernetes/features/blob/master/release-1.6/release_team.md)
+  will use the following procedure to identify release blocking issues
+  1. Any issues listed in the [v1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6)
+     will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the 1.6 milestone and into the 1.6.1 or 1.7
+     milestones **or the release will not ship**
+  1. The release team *will not* use or consider the `release-blocking` or `non-release-blocking` labels although they may have meaning
+     for other members of the community
+  1. The release team *will not* user or consider `priority/*` labels of any kind. There is an ongoing migration away from `priority/p[0-9]` labels
+     in favor of `priority/[a-z]` labels and usage is inconsistent across the project.
+
 # Contact us
 - [via slack](https://kubernetes.slack.com/messages/k8s-release/)
 - [via email](kubernetes-release@googlegroups.com)

--- a/release-1.6/release-1.6.md
+++ b/release-1.6/release-1.6.md
@@ -57,7 +57,7 @@ link](https://docs.google.com/spreadsheets/d/1nspIeRVNjAQHRslHQD1-6gPv99OcYZLMez
 1. Starting in the 1.6 release the [release team](https://github.com/kubernetes/features/blob/master/release-1.6/release_team.md)
   will use the following procedure to identify release blocking issues
   1. Any issues listed in the [v1.6 milestone](https://github.com/kubernetes/kubernetes/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20milestone%3Av1.6)
-     will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the 1.6 milestone and into the 1.6.1 or 1.7
+     will be considered release blocking. It is everyone's responsibility to move non blocking issues out of the `v1.6` milestone. Items targeting 1.7 can be moved into the `v1.7` milestone.
      milestones **or the release will not ship**
   1. The release team *will not* use or consider the `release-blocking` or `non-release-blocking` labels although they may have meaning
      for other members of the community

--- a/release-1.6/release-1.6.md
+++ b/release-1.6/release-1.6.md
@@ -63,6 +63,7 @@ link](https://docs.google.com/spreadsheets/d/1nspIeRVNjAQHRslHQD1-6gPv99OcYZLMez
      for other members of the community
   1. The release team *will not* user or consider `priority/*` labels of any kind. There is an ongoing migration away from `priority/p[0-9]` labels
      in favor of `priority/[a-z]` labels and usage is inconsistent across the project.
+  1. `priority/p*` labels will continue to be used by the submit queue
 
 # Contact us
 - [via slack](https://kubernetes.slack.com/messages/k8s-release/)


### PR DESCRIPTION
notifies community that only milestone will determine whether an issue is release blocking or not