### PR TITLE
Propose Maru Newby as 1.7 Release Manager

### DIFF
--- a/release-1.7/release_team.md
+++ b/release-1.7/release_team.md
@@ -1,6 +1,7 @@
 |  **Role** | **Name** | **GitHub/Slack ID** |
 |  ------ | ------ | ------ |
-|  Lead | | |
+|  Lead | Maru Newby | marun |
+|  Shadow Lead | Shruti Ramesh | |
 |  Secondary || |
 |  Features | | |
 |  Release branch | | |
@@ -8,5 +9,5 @@
 |  Docs | | |
 |  Bugs | | |
 |  Testing | | |
-|  Manual upgrade | | |
+|  Manual upgrade | Anthony Howe | anhowe |
 |  Automatic upgrade | | |


### PR DESCRIPTION
- Propose Maru as 1.7 release manager following his work in the 1.6 release team. 
- Also proposes Shruti Ramesh from Microsoft as shadow release manager with the intent of having Shruti serve as the 1.8 release manager.
 - Propose that Anthony Howe retain role as Manual upgrade lead for 1.7