### PR TITLE
Move kubernetes/kubernetes#42336 to Enhancement of CLI

### DIFF
--- a/release-1.7/release-notes-draft.md
+++ b/release-1.7/release-notes-draft.md
@@ -355,6 +355,8 @@ Continuous integration builds have used the following versions of external depen
 
         * Kubectl --namespace and --cluster now support completion ([#44251](https://github.com/kubernetes/kubernetes/pull/44251), [@superbrothers](https://github.com/superbrothers))
 
+        * Kubectl config use-context now supports completion ([#42336](https://github.com/kubernetes/kubernetes/pull/42336), [@superbrothers](https://github.com/superbrothers))
+
         * Kubectl version now supports --output ([#39858](https://github.com/kubernetes/kubernetes/pull/39858), [@alejandroEsc](https://github.com/alejandroEsc))
 
     * Printing/describe
@@ -374,8 +376,6 @@ Continuous integration builds have used the following versions of external depen
         * Kubectl commands run inside a pod using a kubeconfig file now use the namespace specified in the kubeconfig file, instead of using the pod namespace. If no kubeconfig file is used, or the kubeconfig does not specify a namespace, the pod namespace is still used as a fallback. ([#44570](https://github.com/kubernetes/kubernetes/pull/44570), [@liggitt](https://github.com/liggitt))
 
         * Fixed kubectl cluster-info dump to support multi-container pod. ([#44088](https://github.com/kubernetes/kubernetes/pull/44088), [@xingzhou](https://github.com/xingzhou))
-
-        * Kubectl config use-context now supports completion ([#42336](https://github.com/kubernetes/kubernetes/pull/42336), [@superbrothers](https://github.com/superbrothers))
 
         * Kubectl will print a warning when deleting the current context ([#42538](https://github.com/kubernetes/kubernetes/pull/42538), [@adohe](https://github.com/adohe))
 


### PR DESCRIPTION
It is appropriate that kubernetes/kubernetes#42336 is in Enhancement of CLI.

> * Kubectl config use-context now supports completion ([#42336](https://github.com/kubernetes/kubernetes/pull/42336), [@superbrothers](https://github.com/superbrothers))