### PR TITLE
Updated the release team as it currently stands

### DIFF
--- a/release-1.8/release_team.md
+++ b/release-1.8/release_team.md
@@ -1,11 +1,12 @@
 |  **Role** | **Name** (**GitHub/Slack ID**)  | **Shadow Name(s) (GitHub/Slack ID), ...**
 |  ------ | ------ | ------ |
-|  Lead | | |
-|  Secondary | | |
-|  Features || |
-|  Branch Manager | | |
-|  Test Infra | | | |
-|  Docs || |
-|  Bugs | | | |
-|  Upgrade Testing / CI Signal| | | |
+|  Lead | Jaice Singer DuMars (jdumars) | |
+|  Secondary | Caleb Miles (calebamiles) | |
+|  Features | Ihor Dvoretskyi (idvoretskyi) | |
+|  Branch Manager | Adam Worrall (abgworrall) | |
+|  Test Infra | Sen Lu (krzyzacy) | | |
+|  Docs | | |
+|  Bugs | Aaron Crickenberger (spiffxp) | | |
+|  Upgrade Testing / CI Signal| Eric Chiang (ericchiang) | | |
 | Patch Release Manager | | |
+| Marketing coordinator | | |


### PR DESCRIPTION
Updated to the release team as agreed upon by SIG Release 7/21/2017, 21:00 UTC.  Vacancies still need volunteers.