### PR TITLE
Add `Paramaterize session affinity timeout seconds in service API` to 1.8 release notes

### DIFF
--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -44,3 +44,7 @@ please check out the [release notes guidance][] issue.
 ## **Deprecations**
 
 ## **Notable Features**
+
+### Service
+
+Paramaterize session affinity timeout seconds in service API for Client IP based session affinity.


### PR DESCRIPTION
Add `Paramaterize session affinity timeout seconds in service API` to 1.8 release notes. Original PR, see https://github.com/kubernetes/kubernetes/pull/49850/

@thockin 