### PR TITLE
Checking off SIG Cluster Lifecycle for 1.8 draft.

### DIFF
--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -12,7 +12,7 @@ please check out the [release notes guidance][] issue.
 - [ ] sig-azure
 - [ ] sig-big-data
 - [ ] sig-cli
-- [ ] sig-cluster-lifecycle
+- [x] sig-cluster-lifecycle
 - [ ] sig-cluster-ops
 - [ ] sig-contributor-experience
 - [ ] sig-docs


### PR DESCRIPTION
Our draft was already merged in https://github.com/kubernetes/features/pull/391, so checking off the SIG from the checklist.