### PR TITLE
Fix deprecation announcements for sig-apps

### DIFF
--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -63,10 +63,8 @@ API surface for promotion.
 ## **Deprecations**
 
 ### Apps 
- - The rollbackTo field of the Deployment kind is depreatcted in the 
- apps/v1beta2 group version. 
- - The templateGeneration field of the DaemonSet kinds is deprecated in the 
- apps/v1beta2 group.
+ - The .spec.rollbackTo field of the Deployment kind is deprecated in the
+ extensions/v1beta1 group version.
  - The pod.alpha.kubernetes.io/initialized has been removed.
 
 


### PR DESCRIPTION
apps/v1beta2 is a new API version in 1.8. Changes to this API within the same release does not require a release note. 

extensions/v1beta1 Deployment field deprecation should be announced. 