### PR TITLE
Use "Release Team Lead" rather than "Release Czar" when describing the exception process

### DIFF
--- a/EXCEPTIONS.md
+++ b/EXCEPTIONS.md
@@ -29,13 +29,13 @@ To file for an exception, please fill out the questions below:
 Email them to:
 
 * Your SIG lead
-* The release czar
+* The Release Team Lead
 * kubernetes-milestone-burndown@googlegroups.com
 
 [You should have *very high confidence* on the “additional time needed” number - we will not grant multiple exceptions for a feature.]
 
 Requests for exceptions must be submitted before the first milestone burn down meeting. All requests for exception will be reviewed and either approved or rejected during the first meeting.
 
-Important dates for each release and information about the release czar can be found in the [feature repo](https://github.com/kubernetes/features). For the v1.5 release, for example, see [link](https://github.com/kubernetes/features/blob/master/release-1.5/release-1.5.md).
+Important dates for each release and information about the Release Team Lead can be found in the [feature repo](https://github.com/kubernetes/features). For the v1.5 release, for example, see [link](https://github.com/kubernetes/features/blob/master/release-1.5/release-1.5.md).
 
 Once an exception is approved, it should be broadcast broadly: send an email with the data and approval to kubernetes-dev@ and your SIG group, then follow up with a reply to that email once the feature is completed.


### PR DESCRIPTION
We're a team now so reflect that.

**cc: @kubernetes/kubernetes-release-managers**