### PR TITLE
Mark SIG-OpenStack complete

### DIFF
--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -22,7 +22,7 @@ please check out the [release notes guidance][] issue.
 - [x] sig-network
 - [ ] sig-node
 - [ ] sig-on-premise
-- [ ] sig-openstack
+- [x] sig-openstack
 - [ ] sig-product-management
 - [ ] sig-release
 - [ ] sig-scalability


### PR DESCRIPTION
Marking SIG-OpenStack complete, both v1.8 milestone targeted items were merged with release-note-none.