### PR TITLE
sig-testing release notes for v1.8

### DIFF
--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -29,7 +29,7 @@ please check out the [release notes guidance][] issue.
 - [x] sig-scheduling
 - [x] sig-service-catalog
 - [x] sig-storage
-- [ ] sig-testing
+- [x] sig-testing
 - [ ] sig-ui
 - [ ] sig-windows
 


### PR DESCRIPTION
we have no release artifacts for kubernetes/kubernetes v1.8,
so no release notes either; ongoing improvements are taking
place over in kubernetes/test-infra