### PR TITLE
API Machinery release notes

### DIFF
--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -480,25 +480,25 @@ kind.
 
 
 #### kube-apiserver
-* Fixes an issue with APIService auto-registration affecting rolling HA apiserver restarts that add or remove API groups being served.([#51921](https://github.com/kubernetes/kubernetes/pull/51921))
+* Fixes an issue with `APIService` auto-registration. This issue affected rolling restarts of HA API servers that added or removed API groups being served.([#51921](https://github.com/kubernetes/kubernetes/pull/51921))
 
 * [Alpha] The Kubernetes API server now supports the ability to break large LIST calls into multiple smaller chunks.  A client can specify a limit to the number of results to return, and if more results exist a token will be returned that allows the client to continue the previous list call repeatedly until all results are retrieved.  The resulting list is identical to a list call that does not perform chunking thanks to capabilities provided by etcd3.  This allows the server to use less memory and CPU responding with very large lists.  This feature is gated as APIListChunking and is not enabled by default.  The 1.9 release will begin using this by default from all informers.([#48921](https://github.com/kubernetes/kubernetes/pull/48921))
 
-* Ignore pods marked for deletion that exceed their grace period in ResourceQuota([#46542](https://github.com/kubernetes/kubernetes/pull/46542))
+* Ignore the pods marked for deletion that exceed their grace period in ResourceQuota.([#46542](https://github.com/kubernetes/kubernetes/pull/46542))
 
 
 #### Dynamic Admission Control
 
-* Pod spec is mutable when the pod is uninitialized. The apiserver requires the pod spec to be valid even if it's uninitialized. Updating the status field of uninitialized pods is invalid.([#51733](https://github.com/kubernetes/kubernetes/pull/51733))
+* Pod spec is mutable when the pod is uninitialized. The API server requires the pod spec to be valid even if it's uninitialized. Updating the status field of uninitialized pods is invalid.([#51733](https://github.com/kubernetes/kubernetes/pull/51733))
 
-* Use of the alpha initializers feature now requires enabling the `Initializers` feature gate. This feature gate is auto-enabled if the `Initialzers` admission plugin is enabled.([#51436](https://github.com/kubernetes/kubernetes/pull/51436))
+* Use of the alpha initializers feature now requires enabling the `Initializers` feature gate. This feature gate is auto enabled if the `Initialzers` admission plugin is enabled.([#51436](https://github.com/kubernetes/kubernetes/pull/51436))
 
-* [Action required] validation rule on metadata.initializers.pending[x].name is tightened. The initializer name needs to contain at least three segments separated by dots. If you create objects with pending initializers, (i.e., not relying on apiserver adding pending initializers according to initializerconfiguration), you need to update the initializer name in existing objects and in configuration files to comply to the new validation rule.([#51283](https://github.com/kubernetes/kubernetes/pull/51283))
+* [Action required] validation rule on metadata.initializers.pending[x].name is tightened. The initializer name needs to contain at least three segments separated by dots. You can create objects with pending initializers and not rely on the API server to add pending initializers according to initializerconfiguration. If you do so, update the initializer name in the existing objects and the configuration files to comply to the new validation rule.([#51283](https://github.com/kubernetes/kubernetes/pull/51283))
 
-* Fixed the webhook admission plugin so that it works even if the apiserver and the nodes are in two networks (e.g., in GKE).
+* The webhook admission plugin now works even if the API server and the nodes are in two separate networks. For example, in GKE.
 Fixed the webhook admission plugin so that webhook author could use the DNS name of the service as the CommonName when generating the server cert for the webhook.
 Action required:
-Anyone who generated server cert for admission webhooks need to regenerate the cert. Previously, when generating server cert for the admission webhook, the CN value doesn't matter. Now you must set it to the DNS name of the webhook service, i.e., `<service.Name>.<service.Namespace>.svc`.([#50476](https://github.com/kubernetes/kubernetes/pull/50476))
+Regenerate the server cert for the admission webhooks. Previously, the CN value can be ignored while generating the server cert for the admission webhook. Now you must set it to the DNS name of the webhook service: `<service.Name>.<service.Namespace>.svc`.([#50476](https://github.com/kubernetes/kubernetes/pull/50476))
 
 
 #### Custom Resource Definitions (CRDs)
@@ -515,11 +515,11 @@ Anyone who generated server cert for admission webhooks need to regenerate the c
 
 
 #### Monitoring/Prometheus
-* [action required] WATCHLIST calls are now reported as WATCH verbs in prometheus for the apiserver_request_* series.  A new "scope" label is added to all apiserver_request_* values that is either 'cluster', 'resource', or 'namespace' depending on which level the query is performed at.([#52237](https://github.com/kubernetes/kubernetes/pull/52237))
+* [action required] The WATCHLIST calls are now reported as WATCH verbs in prometheus for the apiserver_request_* series.  A new "scope" label is added to all apiserver_request_* values that is either 'cluster', 'resource', or 'namespace' depending on which level the query is performed at.([#52237](https://github.com/kubernetes/kubernetes/pull/52237))
 
 
 #### Go Client
-* add support for client-side spam filtering of events([#47367](https://github.com/kubernetes/kubernetes/pull/47367))
+* Add support for client-side spam filtering of events([#47367](https://github.com/kubernetes/kubernetes/pull/47367))
 
 
 ## External Dependencies

--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -3,7 +3,7 @@ As SIGs fill out their sections by component, please check off that
 you are finished. For guidance about what should have a release note
 please check out the [release notes guidance][] issue.
 
-- [ ] sig-api-machinery
+- [x] sig-api-machinery
 - [x] sig-apps
 - [x] sig-architecture
 - [x] sig-auth
@@ -478,15 +478,56 @@ kind.
 
 ### API Machinery
 
+
+#### Core API Server
+* Fixes an issue with APIService auto-registration affecting rolling HA apiserver restarts that add or remove API groups being served.([#51921](https://github.com/kubernetes/kubernetes/pull/51921))
+
+* The Kubernetes API server now supports the ability to break large LIST calls into multiple smaller chunks.  A client can specify a limit to the number of results to return, and if more results exist a token will be returned that allows the client to continue the previous list call repeatedly until all results are retrieved.  The resulting list is identical to a list call that does not perform chunking thanks to capabilities provided by etcd3.  This allows the server to use less memory and CPU responding with very large lists.  This feature is gated as APIListChunking and is not enabled by default.  The 1.9 release will begin using this by default from all informers.([#48921](https://github.com/kubernetes/kubernetes/pull/48921))
+
+* Ignore pods marked for deletion that exceed their grace period in ResourceQuota([#46542](https://github.com/kubernetes/kubernetes/pull/46542))
+
+* Add PriorityClassName and Priority fields to PodSpec.([#45610](https://github.com/kubernetes/kubernetes/pull/45610))
+
+
+#### Dynamic Admission Control
+
+* Pod spec is mutable when the pod is uninitialized. The apiserver requires the pod spec to be valid even if it's uninitialized. Updating the status field of uninitialized pods is invalid.([#51733](https://github.com/kubernetes/kubernetes/pull/51733))
+
+* Use of the alpha initializers feature now requires enabling the `Initializers` feature gate. This feature gate is auto-enabled if the `Initialzers` admission plugin is enabled.([#51436](https://github.com/kubernetes/kubernetes/pull/51436))
+
+* Action required: validation rule on metadata.initializers.pending[x].name is tightened. The initializer name needs to contain at least three segments separated by dots. If you create objects with pending initializers, (i.e., not relying on apiserver adding pending initializers according to initializerconfiguration), you need to update the initializer name in existing objects and in configuration files to comply to the new validation rule.([#51283](https://github.com/kubernetes/kubernetes/pull/51283))
+
+* Fixed the webhook admission plugin so that it works even if the apiserver and the nodes are in two networks (e.g., in GKE).
+Fixed the webhook admission plugin so that webhook author could use the DNS name of the service as the CommonName when generating the server cert for the webhook.
+Action required:
+Anyone who generated server cert for admission webhooks need to regenerate the cert. Previously, when generating server cert for the admission webhook, the CN value doesn't matter. Now you must set it to the DNS name of the webhook service, i.e., `<service.Name>.<service.Namespace>.svc`.([#50476](https://github.com/kubernetes/kubernetes/pull/50476))
+
+
+#### Custom Resource Definitions (CRDs)
 * [alpha] The CustomResourceDefinition API can now optionally
   [validate custom objects](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#validation)
   based on a JSON schema provided in the CRD spec.
   Enable this alpha feature with the `CustomResourceValidation` feature gate in `kube-apiserver`.
 
+#### Garbage Collector
 * The garbage collector now supports custom APIs added via CustomResourceDefinition
   or aggregated API servers. The garbage collector controller refreshes periodically.
   Therefore, expect a latency of about 30 seconds between when the API is added and when
   the garbage collector starts to manage it.
+
+
+#### Monitoring/Prometheus
+* WATCHLIST calls are now reported as WATCH verbs in prometheus for the apiserver_request_* series.  A new "scope" label is added to all apiserver_request_* values that is either 'cluster', 'resource', or 'namespace' depending on which level the query is performed at.([#52237](https://github.com/kubernetes/kubernetes/pull/52237))
+
+
+#### Go Client
+* add support for client-side spam filtering of events([#47367](https://github.com/kubernetes/kubernetes/pull/47367))
+
+
+#### Kube Admin
+
+* kubeadm: Adds dry-run support for kubeadm using the `--dry-run` option([#50631](https://github.com/kubernetes/kubernetes/pull/50631))
+
 
 ## External Dependencies
 Continuous integration builds have used Docker versions 1.11.2, 1.12.6, 1.13.1,

--- a/release-1.8/release_notes_draft.md
+++ b/release-1.8/release_notes_draft.md
@@ -479,14 +479,12 @@ kind.
 ### API Machinery
 
 
-#### Core API Server
+#### kube-apiserver
 * Fixes an issue with APIService auto-registration affecting rolling HA apiserver restarts that add or remove API groups being served.([#51921](https://github.com/kubernetes/kubernetes/pull/51921))
 
-* The Kubernetes API server now supports the ability to break large LIST calls into multiple smaller chunks.  A client can specify a limit to the number of results to return, and if more results exist a token will be returned that allows the client to continue the previous list call repeatedly until all results are retrieved.  The resulting list is identical to a list call that does not perform chunking thanks to capabilities provided by etcd3.  This allows the server to use less memory and CPU responding with very large lists.  This feature is gated as APIListChunking and is not enabled by default.  The 1.9 release will begin using this by default from all informers.([#48921](https://github.com/kubernetes/kubernetes/pull/48921))
+* [Alpha] The Kubernetes API server now supports the ability to break large LIST calls into multiple smaller chunks.  A client can specify a limit to the number of results to return, and if more results exist a token will be returned that allows the client to continue the previous list call repeatedly until all results are retrieved.  The resulting list is identical to a list call that does not perform chunking thanks to capabilities provided by etcd3.  This allows the server to use less memory and CPU responding with very large lists.  This feature is gated as APIListChunking and is not enabled by default.  The 1.9 release will begin using this by default from all informers.([#48921](https://github.com/kubernetes/kubernetes/pull/48921))
 
 * Ignore pods marked for deletion that exceed their grace period in ResourceQuota([#46542](https://github.com/kubernetes/kubernetes/pull/46542))
-
-* Add PriorityClassName and Priority fields to PodSpec.([#45610](https://github.com/kubernetes/kubernetes/pull/45610))
 
 
 #### Dynamic Admission Control
@@ -495,7 +493,7 @@ kind.
 
 * Use of the alpha initializers feature now requires enabling the `Initializers` feature gate. This feature gate is auto-enabled if the `Initialzers` admission plugin is enabled.([#51436](https://github.com/kubernetes/kubernetes/pull/51436))
 
-* Action required: validation rule on metadata.initializers.pending[x].name is tightened. The initializer name needs to contain at least three segments separated by dots. If you create objects with pending initializers, (i.e., not relying on apiserver adding pending initializers according to initializerconfiguration), you need to update the initializer name in existing objects and in configuration files to comply to the new validation rule.([#51283](https://github.com/kubernetes/kubernetes/pull/51283))
+* [Action required] validation rule on metadata.initializers.pending[x].name is tightened. The initializer name needs to contain at least three segments separated by dots. If you create objects with pending initializers, (i.e., not relying on apiserver adding pending initializers according to initializerconfiguration), you need to update the initializer name in existing objects and in configuration files to comply to the new validation rule.([#51283](https://github.com/kubernetes/kubernetes/pull/51283))
 
 * Fixed the webhook admission plugin so that it works even if the apiserver and the nodes are in two networks (e.g., in GKE).
 Fixed the webhook admission plugin so that webhook author could use the DNS name of the service as the CommonName when generating the server cert for the webhook.
@@ -517,16 +515,11 @@ Anyone who generated server cert for admission webhooks need to regenerate the c
 
 
 #### Monitoring/Prometheus
-* WATCHLIST calls are now reported as WATCH verbs in prometheus for the apiserver_request_* series.  A new "scope" label is added to all apiserver_request_* values that is either 'cluster', 'resource', or 'namespace' depending on which level the query is performed at.([#52237](https://github.com/kubernetes/kubernetes/pull/52237))
+* [action required] WATCHLIST calls are now reported as WATCH verbs in prometheus for the apiserver_request_* series.  A new "scope" label is added to all apiserver_request_* values that is either 'cluster', 'resource', or 'namespace' depending on which level the query is performed at.([#52237](https://github.com/kubernetes/kubernetes/pull/52237))
 
 
 #### Go Client
 * add support for client-side spam filtering of events([#47367](https://github.com/kubernetes/kubernetes/pull/47367))
-
-
-#### Kube Admin
-
-* kubeadm: Adds dry-run support for kubeadm using the `--dry-run` option([#50631](https://github.com/kubernetes/kubernetes/pull/50631))
 
 
 ## External Dependencies


### PR DESCRIPTION
I generated this release note using github APIs and looking into PRs and Issues with sig-api-machinery label. Thus we may have missed some PRs as we do not mandate sig labels on PRs (yet). The categories are all guesses and needs your comment.

cc @lavalamp @kubernetes/sig-api-machinery-pr-reviews 