### PR TITLE
Remove tombstoned Release folders

### DIFF
--- a/release-1.3/features-1.3.md
+++ b/release-1.3/features-1.3.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.3/features-1.3.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.3/release-1.3.md
+++ b/release-1.3/release-1.3.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.3/release-1.3.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.4/Release-1.4.md
+++ b/release-1.4/Release-1.4.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.4/Release-1.4.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.5/release-1.5.md
+++ b/release-1.5/release-1.5.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.5/release-1.5.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.5/release-notes-draft.md
+++ b/release-1.5/release-notes-draft.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.5/release-notes-draft.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/flake-reports/2017-03-03.md
+++ b/release-1.6/flake-reports/2017-03-03.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/flake-reports/2017-03-03.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-06.md
+++ b/release-1.6/go-signal-reports/2017-03-06.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-06.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-08.md
+++ b/release-1.6/go-signal-reports/2017-03-08.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-08.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-10.md
+++ b/release-1.6/go-signal-reports/2017-03-10.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-10.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-13.md
+++ b/release-1.6/go-signal-reports/2017-03-13.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-13.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-14.md
+++ b/release-1.6/go-signal-reports/2017-03-14.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-14.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-15.md
+++ b/release-1.6/go-signal-reports/2017-03-15.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-15.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-16.md
+++ b/release-1.6/go-signal-reports/2017-03-16.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-16.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-17.md
+++ b/release-1.6/go-signal-reports/2017-03-17.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-17.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-20.md
+++ b/release-1.6/go-signal-reports/2017-03-20.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-20.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-21.md
+++ b/release-1.6/go-signal-reports/2017-03-21.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-21.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-22.md
+++ b/release-1.6/go-signal-reports/2017-03-22.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-22.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-23.md
+++ b/release-1.6/go-signal-reports/2017-03-23.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-23.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/go-signal-reports/2017-03-24.md
+++ b/release-1.6/go-signal-reports/2017-03-24.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/go-signal-reports/2017-03-24.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/release-1.6.md
+++ b/release-1.6/release-1.6.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/release-1.6.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/release-notes-draft.md
+++ b/release-1.6/release-notes-draft.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/release-notes-draft.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.6/release_team.md
+++ b/release-1.6/release_team.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.6/release_team.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.7/release-1.7.md
+++ b/release-1.7/release-1.7.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.7/release-1.7.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.7/release-notes-draft.md
+++ b/release-1.7/release-notes-draft.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.7/release-notes-draft.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.7/release_team.md
+++ b/release-1.7/release_team.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.7/release_team.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.7/release_team_absence_tracker.md
+++ b/release-1.7/release_team_absence_tracker.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.7/release_team_absence_tracker.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.8/add_release_notes_email_template.md
+++ b/release-1.8/add_release_notes_email_template.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.8/add_release_notes_email_template.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.8/release-1.8.md
+++ b/release-1.8/release-1.8.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.8/release-1.8.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.8/release-notes-draft.md
+++ b/release-1.8/release-notes-draft.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.8/release-notes-draft.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.8/release_notes_discussion.md
+++ b/release-1.8/release_notes_discussion.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.8/release_notes_discussion.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.8/release_team.md
+++ b/release-1.8/release_team.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.8/release_team.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.8/scalability_validation_report.md
+++ b/release-1.8/scalability_validation_report.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.8/scalability_validation_report.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.9/release-1.9.md
+++ b/release-1.9/release-1.9.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.9/release-1.9.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.9/release-notes-draft.md
+++ b/release-1.9/release-notes-draft.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.9/release-notes-draft.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.9/release_notes_discussion.md
+++ b/release-1.9/release_notes_discussion.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.9/release_notes_discussion.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.9/release_team.md
+++ b/release-1.9/release_team.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.9/release_team.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

--- a/release-1.9/scalability_validation_report.md
+++ b/release-1.9/scalability_validation_report.md
@@ -1,3 +1,0 @@
-The original content of this file has been migrated to https://git.k8s.io/sig-release/releases/release-1.9/scalability_validation_report.md
-
-This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.


### PR DESCRIPTION
Per the tombstone notice:
> This file is a placeholder to preserve links. Please remove after 3 months or the release of kubernetes 1.10, whichever comes first.

I'm removing these files as k8s 1.10 has been released.

Historical Release information can be found here: https://git.k8s.io/sig-release/releases
