### PR TITLE
Add `features-maintainers` section to OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs: https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 
 approvers:
+- features-maintainers
 - release-team-leads
 - sig-release-leads
 - sig-pm-leads

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
 
 aliases:
+  features-maintainers:
+    - idvoretskyi
+    - justaugustus
   patch-release-managers:
     - enisoc
     - fabioy


### PR DESCRIPTION
This adds an additional section to `OWNERS[_ALIASES]` for the Release Team Features Lead.
Mostly for giving me magic powers to approve PRs in `k/features` for the next (1.12) release.

/assign @idvoretskyi @calebamiles  