### PR TITLE
Fixed Broken Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Feature Tracking and Backlog
 
-Feature tracking repo for Kubernetes releases. Owned by [Product Management SIG](https://github.com/kubernetes/community/blob/master/sig-product-management/README.md).
+Feature tracking repo for Kubernetes releases. Owned by [PM SIG](https://github.com/kubernetes/community/blob/master/sig-pm/README.md).
 
 This repo only contains issues. These issues are umbrellas for new features to be added to Kubernetes. A feature usually takes multiple releases to complete. And a feature can be tracked as backlog items before work begins. A feature may be filed once there is consensus in at least one [Kubernetes SIG](https://git.k8s.io/community/sig-list.md).
 
 ## Is My Thing a Feature?
 
-We are trying to figure out the exact shape of a feature. Until then here are a few rough heuristics. 
+We are trying to figure out the exact shape of a feature. Until then here are a few rough heuristics.
 
 A feature is anything that:
 
-- a blog post would be written about after its release (ex. [minikube](http://blog.kubernetes.io/2016/07/minikube-easily-run-kubernetes-locally.html), [StatefulSets](http://blog.kubernetes.io/2016/07/thousand-instances-of-cassandra-using-kubernetes-pet-set.html), [rkt container runtime](http://blog.kubernetes.io/2016/07/rktnetes-brings-rkt-container-engine-to-Kubernetes.html))
+- a blog post would be written about after its release (ex. [minikube](https://kubernetes.io/blog/2016/07/minikube-easily-run-kubernetes-locally/), [StatefulSets](https://kubernetes.io/blog/2016/07/thousand-instances-of-cassandra-using-kubernetes-pet-set/), [rkt container runtime](https://kubernetes.io/blog/2016/07/rktnetes-brings-rkt-container-engine-to-kubernetes/))
 - requires multiple parties/SIGs/owners participating to complete (ex. GPU scheduling [API, Core, & Node], StatefulSets [Storage & API])
 - needs significant effort or changes Kubernetes in a significant way (ex. something that would take 10 person-weeks to implement, introduce or redesign a system component, or introduces API changes)
 - impacts the UX or operation of Kubernetes substantially such that engineers using Kubernetes will need retraining
@@ -23,7 +23,7 @@ It is unlikely a feature if it is:
 - performance improvements, which are only visible to users as faster API operations, or faster control loops
 - adding error messages or events
 
-If you are not sure, ask someone in the SIG where you initially circulated the idea. If they aren't sure jump into 
+If you are not sure, ask someone in the SIG where you initially circulated the idea. If they aren't sure jump into
 [#kubernetes-pm](https://kubernetes.slack.com/messages/kubernetes-pm/) on Slack or ping someone listed in [OWNERS](https://github.com/kubernetes/features/blob/master/OWNERS).
 
 ## When to Create a New Feature Issue
@@ -43,7 +43,7 @@ Once users adopt a feature, they expect to use it for an extended period of time
 high standard of conceptual integrity and require consistency with other parts of the system, thorough testing, and complete
 documentation. As the project grows no single person can track whether all those requirements are met. The development
 of a feature often spans three stages: Alpha, Beta, and Stable; feature Tracking Issues provide a
-checklist that allows for different approvers for different aspects, and ensures that nothing is forgotten across the 
+checklist that allows for different approvers for different aspects, and ensures that nothing is forgotten across the
 development lifetime of a feature.
 
 ## When to Comment on a Feature Issue


### PR DESCRIPTION
Fixed a broken link pointing to an old version of SIG Product Management to PM SIG. Adjusted the links pointing to the blogs after the new blog cutover so there is no redirection page

/assign @justaugustus

Signed-off-by: Kendrick Coleman <kendrickc@vmware.com>